### PR TITLE
Replace auth_get with retry_get in syncs

### DIFF
--- a/tap_sendgrid/http.py
+++ b/tap_sendgrid/http.py
@@ -46,4 +46,4 @@ def retry_get(tap_stream_id, url, config, params=None):
             return r
     logger.error(f'Status code of latest attempt: {r.status_code}')
     logger.error(f'Latest attempt response {r.content}')
-    raise ValueError(f'Failed {rerties} times trying to hit endpoint {url}')
+    raise ValueError(f'Failed {retries} times trying to hit endpoint {url}')

--- a/tap_sendgrid/syncs.py
+++ b/tap_sendgrid/syncs.py
@@ -3,7 +3,7 @@ import singer
 from simplejson.scanner import JSONDecodeError
 
 from .streams import IDS
-from .http import authed_get, end_of_records_check, retry_get
+from .http import end_of_records_check, retry_get
 from .utils import (
     trimmed_records, trim_members_all, get_results_from_payload,
     safe_update_dict,
@@ -119,7 +119,7 @@ class Syncer(object):
         if stream.tap_stream_id == IDS.GROUPS_MEMBERS:
             url_key = list['id']
             endpoint = stream.endpoint.format(url_key)
-            result = get_results_from_payload(authed_get(
+            result = get_results_from_payload(retry_get(
                 stream.tap_stream_id, endpoint, self.ctx.config).json())
             self.write_records(schema, result, stream,
                                 added_properties=added_properties)
@@ -175,7 +175,7 @@ class Syncer(object):
                 'page_size': page_size
             }
             safe_update_dict(params, add_params)
-            r = authed_get(stream.tap_stream_id,
+            r = retry_get(stream.tap_stream_id,
                            endpoint,
                            self.ctx.config,
                            params=params)
@@ -191,7 +191,7 @@ class Syncer(object):
         endpoint = stream.endpoint.format(url_key) if url_key else stream.endpoint
 
         while True:
-            r = get_results_from_payload(authed_get(
+            r = get_results_from_payload(retry_get(
                 stream.tap_stream_id,
                 endpoint,
                 self.ctx.config,


### PR DESCRIPTION
- Replace auth_get with retry_get in syncs (retry_get is a retry wrapper for auth_get, so a simple replacement of auth_get with retry_get is a valid modification)
- Fix a small bug in retry_get method

## Testing
I've done manual testing on my laptop to ensure it works

## Risk
It's relatively risk-free